### PR TITLE
fix : allow to load package even if SENDGRID_API is defined

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,7 +1,9 @@
 .onLoad <- function(libname, pkgname){
   if (Sys.getenv("SENDGRID_API") != "") {
+    try(
     keyring::key_set_with_value(service = "apikey",
                                 username = "sendgridr",
                                 password = Sys.getenv("SENDGRID_API"))
+      )
   }
 }


### PR DESCRIPTION
fix : add a try in .onLoad to avoid the issue we had when SENDGRID_API is defined and. 

We ran into this issue when building a package depending on sendgridr, the check failed because of setting non-interactively a key into keyring.


(maybe setting an if (interactive()) should be a better approach)